### PR TITLE
Add: adicionando livro python para desenvolvedores

### DIFF
--- a/livros/python.md
+++ b/livros/python.md
@@ -6,3 +6,4 @@
 [Grupo Python - Módulo B]([[https://www.faeterj-rio.edu.br/downloads/bbv/0031.pdf](https://www.dcc.ufrj.br/~fabiom/mab225/pythonbasico.pdf](https://www.cos.ufrj.br/~bfgoldstein/python/pythonoo.pdf)))
 (Dica de [Dandara](https://github.com/dandaramcsousa))
 
+[Python para desenvolvedores](https://livros01.livrosgratis.com.br/ea000474.pdf) (Luiz Eduardo Borges) (Dica de [Yuri Melo](https://github.com/YuriMel0))


### PR DESCRIPTION
Adicionando livro "Python para desenvolvedores" licenciado sob uma Licença Creative Commons Atribuição-Uso NãoComercial-Compartilhamento, para estudos e consultas.